### PR TITLE
Enable unit tests by default

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
     types
+    unit
 isolated_build = true
 skipsdist = true
 


### PR DESCRIPTION
When [tox] is invoked without specifying any environments, it runs
whatever is specified under `envlist` in its config. I had intended to
add the `unit` environment when  unit tests were added in 701188d but I
forgot. Fortunately this only applies to running the tests locally as
each environment is run separately in CI.

[tox]: https://tox.readthedocs.io
