### PR TITLE
Base playlist names on common prefix of cue files

### DIFF
--- a/cue2m3u/__init__.py
+++ b/cue2m3u/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from argparse import ArgumentParser
+from os.path import basename, commonprefix
 from pathlib import Path
 
 __version__ = "0.1.0"
@@ -29,8 +30,9 @@ def main() -> None:
         cues: list[Path] = []
 
         for item in path.iterdir():
-            if item.is_dir() and args.recursive:
-                paths.append(item)
+            if item.is_dir():
+                if args.recursive:
+                    paths.append(item)
                 continue
 
             if item.suffix == ".m3u":
@@ -43,8 +45,27 @@ def main() -> None:
         if not cues:
             continue
 
-        playlist = cues[0].with_suffix(".m3u")
+        name = _find_common_prefix(cues)
+        playlist = cues[0].with_name(name).with_suffix(".m3u")
+
         print(f"Generating {playlist}")
         with open(playlist, "w") as f:
             for cue in sorted(cues):
                 f.write(f"{cue.name}\n")
+
+
+def _find_common_prefix(paths: list[Path]) -> str:
+    prefix = commonprefix(paths)
+    prefix = basename(prefix)
+    return _trim_trailing_characters(prefix)
+
+
+def _trim_trailing_characters(s: str) -> str:
+    # This is a very naive implementation. It assumes reasonable use of
+    # parentheses in file names and can be tripped up by things like
+    # multiple sets of unbalanced parentheses.
+    last_open_index = s.rindex("(") if "(" in s else -1
+    last_close_index = s.rindex(")") if ")" in s else -1
+    if last_open_index > last_close_index:
+        s = s[:last_open_index]
+    return s.strip()

--- a/poetry.lock
+++ b/poetry.lock
@@ -7,6 +7,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "atomicwrites"
+version = "1.4.0"
+description = "Atomic file writes."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
 name = "attrs"
 version = "21.2.0"
 description = "Classes Without Boilerplate"
@@ -146,6 +154,14 @@ python-versions = ">=3.6.1"
 
 [package.extras]
 license = ["editdistance-s"]
+
+[[package]]
+name = "iniconfig"
+version = "1.1.1"
+description = "iniconfig: brain-dead simple config-ini parsing"
+category = "dev"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "isort"
@@ -301,6 +317,27 @@ optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "pytest"
+version = "6.2.4"
+description = "pytest: simple powerful testing with Python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
+attrs = ">=19.2.0"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=0.12,<1.0.0a1"
+py = ">=1.8.2"
+toml = "*"
+
+[package.extras]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
+
+[[package]]
 name = "pyyaml"
 version = "5.4.1"
 description = "YAML parser and emitter for Python"
@@ -384,12 +421,16 @@ testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "43fd02ea9562a7d8a28f8558c0f817dd144d1e6580c1ec33ef2510d7cde7c7f3"
+content-hash = "87f2abb4ef3231e5415097810eec19b3c5ede0486c31a06ec6a7c385655c1586"
 
 [metadata.files]
 appdirs = [
     {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
     {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
+]
+atomicwrites = [
+    {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
+    {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
 ]
 attrs = [
     {file = "attrs-21.2.0-py2.py3-none-any.whl", hash = "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1"},
@@ -438,6 +479,10 @@ flake8-polyfill = [
 identify = [
     {file = "identify-2.2.11-py2.py3-none-any.whl", hash = "sha256:7abaecbb414e385752e8ce02d8c494f4fbc780c975074b46172598a28f1ab839"},
     {file = "identify-2.2.11.tar.gz", hash = "sha256:a0e700637abcbd1caae58e0463861250095dfe330a8371733a471af706a4a29a"},
+]
+iniconfig = [
+    {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
+    {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
 isort = [
     {file = "isort-5.9.2-py3-none-any.whl", hash = "sha256:eed17b53c3e7912425579853d078a0832820f023191561fcee9d7cae424e0813"},
@@ -519,6 +564,10 @@ pyflakes = [
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
     {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
+]
+pytest = [
+    {file = "pytest-6.2.4-py3-none-any.whl", hash = "sha256:91ef2131a9bd6be8f76f1f08eac5c5317221d6ad1e143ae03894b862e8976890"},
+    {file = "pytest-6.2.4.tar.gz", hash = "sha256:50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b"},
 ]
 pyyaml = [
     {file = "PyYAML-5.4.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ isort = "^5.9.2"
 mypy = "^0.910"
 pep8-naming = "^0.12.0"
 pre-commit = "^2.13.0"
+pytest = "^6.2.4"
 tox = "^3.24.0"
 
 [tool.isort]

--- a/tests/test_cue2m3u.py
+++ b/tests/test_cue2m3u.py
@@ -1,7 +1,67 @@
 from __future__ import annotations
 
-from cue2m3u import __version__
+from pathlib import Path, PurePath
+
+import pytest
+
+from cue2m3u import _find_common_prefix, _trim_trailing_characters
 
 
-def test_version():
-    assert __version__ == "0.1.0"
+@pytest.mark.parametrize(
+    ("expected", "paths"),
+    (
+        ("prefix", [PurePath("prefix")]),
+        ("prefix", [PurePath("prefix"), PurePath("prefix2")]),
+        ("prefix", [PurePath("prefix1"), PurePath("prefix2"), PurePath("prefix3")]),
+        ("prefix", [PurePath("prefix (1)"), PurePath("prefix (2)")]),
+    ),
+)
+def test_find_common_prefix(expected: str, paths: list[Path]) -> None:
+    actual = _find_common_prefix(paths)
+    assert actual == expected
+
+
+@pytest.mark.parametrize("expected", ("()", "()()", "abc()", "(abc)", "()abc"))
+def test_trim_trailing_whitespace_leaves_balanced_parentheses_intact(
+    expected: str,
+) -> None:
+    actual = _trim_trailing_characters(expected)
+    assert actual == expected
+
+
+@pytest.mark.parametrize("expected", ("abc", "def", "abc def"))
+def test_trim_trailing_whitespace_leaves_ordinary_names_intact(expected: str) -> None:
+    actual = _trim_trailing_characters(expected)
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    ("initial", "expected"),
+    (
+        ("abc(", "abc"),
+        ("(", ""),
+        ("()(", "()"),
+    ),
+)
+def test_trim_trailing_whitespace_removes_unbalanced_parentheses(
+    initial: str, expected: str
+) -> None:
+    actual = _trim_trailing_characters(initial)
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    ("initial", "expected"),
+    (
+        ("abc ", "abc"),
+        ("abc  ", "abc"),
+        ("abc   ", "abc"),
+        (" abc ", "abc"),
+        (" abc", "abc"),
+    ),
+)
+def test_trim_trailing_characters_removes_whitespace(
+    initial: str, expected: str
+) -> None:
+    actual = _trim_trailing_characters(initial)
+    assert actual == expected


### PR DESCRIPTION
Currently, running this script on a folder that contains multiple `cue`
files will result in using the name of the first (alphabetically) `cue`
file as the basis for the name of the `m3u` file. This can lead to some
strange names like

    Some Game (Disc 1).m3u

This introduces two new functions that combine to reduce this down to a
name based on the common prefix shared by all `cue` files in the folder.

    Some Game.m3u

Closes #2
