### PR TITLE
Fix Dependabot schedule to be weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     pull-request-branch-name:
       separator: "-"
 


### PR DESCRIPTION
I mistakenly set the [GitHub Actions][actions] update schedule to daily.
I had intended for it to be weekly. This corrects that.

References #6

[actions]: https://docs.github.com/en/actions