### PR TITLE
Add a command line interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,223 @@
 version = 3
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
 name = "cue2m3u"
 version = "0.1.0"
+dependencies = [
+ "structopt",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "libc"
+version = "0.2.112"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f84e92c0f7c9d58328b85a78557813e4bd845130db68d7184635344399423b1"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "structopt"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "version_check"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ license-file = "LICENSE"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+structopt = "0.3.25"

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,8 @@ use structopt::StructOpt;
 enum Cli {
     #[structopt(name = "generate", about = "Generate playlists")]
     Generate {
+        #[structopt(long, short, help = "Scan subfolders of `input`")]
+        recursive: bool,
         #[structopt(
             required = true,
             help = "Location of the games to generate playlists for"
@@ -17,7 +19,11 @@ enum Cli {
 
 fn dispatch() -> Result<(), ()> {
     match Cli::from_args() {
-        Cli::Generate { source } => println!("generate playlists for {:?}", source),
+        Cli::Generate { source, recursive } => println!(
+            "generate playlists for {:?}{}",
+            source,
+            if recursive { " recursively" } else { "" }
+        ),
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,8 @@ enum Cli {
     Generate {
         #[structopt(long, short, help = "Scan subfolders of `input`")]
         recursive: bool,
+        #[structopt(long, short, help = "Overwrite existing playlists")]
+        overwrite: bool,
         #[structopt(
             required = true,
             help = "Location of the games to generate playlists for"
@@ -19,10 +21,15 @@ enum Cli {
 
 fn dispatch() -> Result<(), ()> {
     match Cli::from_args() {
-        Cli::Generate { source, recursive } => println!(
-            "generate playlists for {:?}{}",
+        Cli::Generate {
             source,
-            if recursive { " recursively" } else { "" }
+            recursive,
+            overwrite,
+        } => println!(
+            "generate playlists for {:?}{}, {} existing",
+            source,
+            if recursive { " recursively" } else { "" },
+            if overwrite { "overwrite" } else { "skip" }
         ),
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::process;
 use structopt::StructOpt;
 
@@ -5,12 +6,18 @@ use structopt::StructOpt;
 #[structopt(name = "cue2m3u", about = "Generate playlists for disc-based games.")]
 enum Cli {
     #[structopt(name = "generate", about = "Generate playlists")]
-    Generate {},
+    Generate {
+        #[structopt(
+            required = true,
+            help = "Location of the games to generate playlists for"
+        )]
+        source: PathBuf,
+    },
 }
 
 fn dispatch() -> Result<(), ()> {
     match Cli::from_args() {
-        Cli::Generate {} => println!("generate playlists"),
+        Cli::Generate { source } => println!("generate playlists for {:?}", source),
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,27 @@
+use std::process;
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+#[structopt(name = "cue2m3u", about = "Generate playlists for disc-based games.")]
+enum Cli {
+    #[structopt(name = "generate", about = "Generate playlists")]
+    Generate {},
+}
+
+fn dispatch() -> Result<(), ()> {
+    match Cli::from_args() {
+        Cli::Generate {} => println!("generate playlists"),
+    }
+
+    Ok(())
+}
+
 fn main() {
-    println!("Hello, world!");
+    process::exit(match dispatch() {
+        Ok(_) => 0,
+        Err(e) => {
+            eprintln!("error: {:?}", e);
+            1
+        }
+    });
 }


### PR DESCRIPTION
While no real functionality is being added here, this adds the command line
interface itself. For now this consists of a single subcommand, `generate`, that
takes a path and generates a playlist for any `cue` files found in the folder.
If the `--recursive` option is set, `generate` will generate a playlist for each
folder it finds inside the source folder that contains one or more `cue` files.
Finally, if the `--overwrite` option is set, rather than skipping any playlists
that already exist, `generate` will overwrite them.

