### PR TITLE
Strip source path from cue paths

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,10 @@ fn generate_playlists(source: PathBuf, recursive: bool, overwrite: bool) -> Resu
         if overwrite { "overwrite" } else { "skip" }
     );
     if let Ok(cue_files) = find_cue_files(&source, recursive) {
+        let cue_files: Vec<PathBuf> = cue_files
+            .into_iter()
+            .map(|f| f.strip_prefix(&source).unwrap().to_owned())
+            .collect();
         println!("found {:?}", cue_files);
     } else {
         return Err("Error finding cue files".to_owned());


### PR DESCRIPTION
When creating the `m3u` files, paths that are relative to it are needed
for the `cue` files. Right now we only have an absolute path. This will
strip out the source path, leaving us with a relative path instead.
These new paths can be dropped right into the `m3u` files.
